### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#ENPopUp
+# ENPopUp
 
 An UIViewController category to display any view controller in a modal popup.
 
-##Demo
+## Demo
 ![](http://i.imgur.com/009XmRb.gif)
 
 
-##Usage
+## Usage
 Import the category 
 ```objc
 #import "UIViewController+ENPopUp.h" 
@@ -14,7 +14,7 @@ Import the category
 then use `[self presentPopUpViewController:popUpViewController];` <br />
 to dismiss the popup, use `[self dismissPopUpViewController];` <br />
 
-##License
+## License
 
 The MIT License (MIT)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
